### PR TITLE
Add strict mode to install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -euo pipefail
+
 cd $HELM_PLUGIN_DIR
 version="$(cat plugin.yaml | grep "version" | cut -d '"' -f 2)"
 echo "Installing helm-gcs ${version} ..."


### PR DESCRIPTION
Strict mode will cause install.sh to immediately exit when an error is encountered.